### PR TITLE
changed so that dosnt try to require thigns unless it needs to

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@ Standardised sequelize migration wrapper, takes a persistence.initialise functio
 
 # Usage
 - Command line
+
+``` javascript
+cd my-cool-project/migrations && sequelize-migrate -u
+cd my-cool-project/migrations && sequelize-migrate -c my-cool-new-migration
 ```
-cd my-cool-project/migrations && ./migrate -u
-cd my-cool-project/migrations && ./migrate -c my-cool-new-migration
-```
+
 - Programatically
-```
+
+``` javascript
 var migrate = require('sequelize-migrate');
 
 migrate(

--- a/cli
+++ b/cli
@@ -66,15 +66,20 @@ function migrationCallback(error, migrations) {
 
 function parseOptions() {
     var options = cli.parse(),
-        persistence = options.persistence ? require(options.persistence) : require(path.join(process.cwd(), '../server/persistence')),
-        config = options.config ? require(options.config) : require(path.join(process.cwd(), './config')),
-        migrations = options.migrations ? options.migrations : path.join(process.cwd(), './migrations'),
-        migrate = require('./index');
+        migrations = options.migrations ? options.migrations : path.join(process.cwd(), './migrations');
 
     if ((!options.up && !options.down && !options.create) ||
         (options.up && options.down) || options.help) {
         return showUsage();
     }
+
+    if (options.create) {
+        return createMigration(options.create, migrations);
+    }
+
+    var persistence = options.persistence ? require(options.persistence) : require(path.join(process.cwd(), '../server/persistence')),
+        config = options.config ? require(options.config) : require(path.join(process.cwd(), './config')),
+        migrate = require('./index');
 
     if (options.up) {
         return migrate(persistence, config, 'up', migrations, options.to, migrationCallback);
@@ -82,10 +87,6 @@ function parseOptions() {
 
     if (options.down) {
         return migrate(persistence, config, 'down', migrations, options.to, migrationCallback);
-    }
-
-    if (options.create) {
-        return createMigration(options.create, migrations);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "sequelize-migrate": "./cli"
   },
   "scripts": {
-    "test": "node ./tests",
-    "prepush": "jshint . && npm test"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
@@ -26,5 +25,12 @@
     "kgo": "^3.1.2",
     "mr-potato-head": "^1.0.0",
     "umzug": "^1.6.0"
-  }
+  },
+  "keywords": [
+    "sequelize",
+    "migration",
+    "migrate",
+    "database",
+    "mysql"
+  ]
 }


### PR DESCRIPTION
Couldn't create a migration or even show help without requiring the persistence layer unnecessarily.

Also cleaned up the `package.json` as non used scripts were specified
